### PR TITLE
다크모드 js 리팩토링, 카드 짝 맞추기 게임 구현

### DIFF
--- a/css/poke_card.css
+++ b/css/poke_card.css
@@ -1,0 +1,94 @@
+@charset "UTF-8";
+/* 포켓몬 카드 짝맞추기 css */
+
+@import url('https://webfontworld.github.io/DungGeunMo/DungGeunMo.css');
+/* 둥근모꼴 */
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+:root {
+    font-family: 'DungGeunMo';
+}
+body {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 50px 0;
+    margin: 0;
+    background-color: #ffffff;
+}
+h1 {
+    margin-bottom: 30px;
+}
+.gameContainer {
+    text-align: center;
+}
+.cardGrid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 10px;
+    margin-top: 20px;
+}
+.card {
+    width: 155px;
+    height: 205px;
+    position: relative;
+    transform-style: preserve-3d;
+    transition: transform 0.6s;
+}
+.card.flipped {
+    transform: rotateY(180deg);
+}
+.card .front, .card .back {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    backface-visibility: hidden;
+    border-radius: 10px;
+}
+.card .front {
+    background: url('/ex/img/pokeCard.png') no-repeat center center;
+    background-size: cover;
+    transform: rotateY(0deg);
+}
+.card .back {
+    background-color: #fff;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    transform: rotateY(180deg);
+}
+.card img {
+    width: 100%;
+    height: 100%;
+    border-radius: 10px;
+}
+.card.matched {
+    visibility: hidden;
+}
+.gameComplete {
+    display: none;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 20px;
+}
+.restartButton {
+    font-family: 'DungGeunMo';
+    padding: 10px 20px;
+    border: none;
+    background-color: #FDA7A7;
+    margin-top: 20px;
+    cursor: pointer;
+    transition: 0.3s;
+    font-size: 16px;
+    color: #fff;
+}
+.restartButton:hover {
+    opacity: 0.6;
+}

--- a/html/poke_card.html
+++ b/html/poke_card.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ko">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>포켓몬 카드 짝 맞추기 게임</title>
+    <link rel="stylesheet" href="/pokemon/css/poke_card.css">
+</head>
+
+<body>
+    <div class="gameContainer">
+        <h1>포켓몬 카드 짝 맞추기 게임</h1>
+        <div class="cardGrid"></div>
+        <div class="gameComplete">
+            <p>축하합니다! 모든 카드를 맞췄습니다!</p>
+            <button class="restartButton">다시 하기</button>
+        </div>
+    </div>
+    <script src="/pokemon/js/poke_card.js"></script>
+</body>
+
+</html>

--- a/js/main_menu_darkmode.js
+++ b/js/main_menu_darkmode.js
@@ -40,68 +40,50 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 });
 
-//라이트, 다크모드 버튼 토글
-lightDarkToggle.addEventListener('click', function () {
-    this.classList.toggle('dark');
+// 다크모드 토글 리팩토링
+// 클래스 토글 함수
+function toggleClass(selector, className) {
+    const elements = document.querySelectorAll(selector);
+    elements.forEach(element => {
+        element.classList.toggle(className);
+    });
 }
-);
 
-// 배경, 폰트 다크모드
-function elementDarkToggle() {
-    document.body.classList.toggle('darkMode');
-    document.querySelector('.typeTitle').classList.toggle('darkMode');
-    document.querySelector('h2').classList.toggle('darkMode');
-    document.querySelector('#search').classList.toggle('darkSearch');
-    document.querySelector('.menu').classList.toggle('darkMode');
-    const catMenuItems = document.querySelectorAll('.catMenu p');
-    catMenuItems.forEach(item => {
-        item.classList.toggle('darkMenuBtn');
-    });
-    const userMenuItems = document.querySelectorAll('.userMenu p');
-    userMenuItems.forEach(item => {
-        item.classList.toggle('darkMenuBtn');
-    });
-    document.querySelector('header').classList.toggle('darkHeader');
-    document.getElementById('scrollUp').classList.toggle('darkScrollUp');
+// 이미지 토글 함수
+function toggleImage(elementId, lightSrc, darkSrc) {
+    const img = document.getElementById(elementId);
+    img.src = img.src.endsWith(lightSrc) ? darkSrc : lightSrc;
+}
 
+// 라이트, 다크모드 버튼 토글
+document.getElementById('lightDarkToggle').addEventListener('click', function () {
+    this.classList.toggle('dark');
 
-    const langImg = document.getElementById('lang');
-    const loginImg = document.getElementById('login');
+    // 배경, 폰트 다크모드 토글
+    toggleClass('body', 'darkMode');
+    toggleClass('.typeTitle', 'darkMode');
+    toggleClass('h2', 'darkMode');
+    toggleClass('#search', 'darkSearch');
+    toggleClass('.menu', 'darkMode');
+    toggleClass('.catMenu p', 'darkMenuBtn');
+    toggleClass('.userMenu p', 'darkMenuBtn');
+    toggleClass('header', 'darkHeader');
+    toggleClass('#scrollUp', 'darkScrollUp');
 
-    if (langImg.src.endsWith('/pokemon/img/lang.png')) {
-        langImg.src = '/pokemon/img/lang_dark.png';
-    } else {
-        langImg.src = '/pokemon/img/lang.png';
-    }
+    // 이미지 다크모드 토글
+    toggleImage('lang', '/pokemon/img/lang.png', '/pokemon/img/lang_dark.png');
+    toggleImage('login', '/pokemon/img/login.png', '/pokemon/img/login_dark.png');
 
-    if (loginImg.src.endsWith('/pokemon/img/login.png')) {
-        loginImg.src = '/pokemon/img/login_dark.png';
-    } else {
-        loginImg.src = '/pokemon/img/login.png';
-    }
-
+    // 검색 버튼 이미지 토글
     const searchBt = document.getElementById('searchBt');
     const searchBtStyle = window.getComputedStyle(searchBt);
-    if (searchBtStyle.backgroundImage.includes('/pokemon/img/search_icon.png')) {
-        searchBt.style.backgroundImage = 'url("/pokemon/img/search_dark.png")';
-    } else {
-        searchBt.style.backgroundImage = 'url("/pokemon/img/search_icon.png")';
-    }
-}
+    searchBt.style.backgroundImage = searchBtStyle.backgroundImage.includes('/pokemon/img/search_icon.png')
+        ? 'url("/pokemon/img/search_dark.png")'
+        : 'url("/pokemon/img/search_icon.png")';
 
-document.getElementById('lightDarkToggle').addEventListener('click', elementDarkToggle);
-
-
-//카드 다크모드
-function cardOneDarkToggle() {
-    const cards = document.querySelectorAll('.cardOne');
-    cards.forEach(card => {
-        card.classList.toggle('darkBtn');
-    });
-}
-
-lightDarkToggle.addEventListener('click', cardOneDarkToggle);
-// lightDarkToggle.addEventListener('click', elementDarkToggle);
+    // 카드 다크모드 토글
+    toggleClass('.cardOne', 'darkBtn');
+});
 
 // 화면 최상단으로 스크롤
 function scrollToTop() {

--- a/js/poke_card.js
+++ b/js/poke_card.js
@@ -1,0 +1,112 @@
+// scripts.js
+
+let pokemonData = [];
+let firstCard = null;
+let secondCard = null;
+let lockBoard = false;
+let matches = 0;
+
+document.addEventListener("DOMContentLoaded", () => {
+  loadPokemons();
+});
+
+async function loadPokemons() {
+  const offset = Math.floor(Math.random() * 1000); // 1000 이내의 랜덤 오프셋 설정
+  const response = await fetch(`https://pokeapi.co/api/v2/pokemon?offset=${offset}&limit=10`);
+  const data = await response.json();
+  const pokemons = data.results;
+
+  // 10쌍의 포켓몬을 가져와서 중복된 배열 만들기
+  pokemonData = [...pokemons, ...pokemons].map(pokemon => ({
+    ...pokemon,
+    id: Math.random()
+  }));
+
+  // 카드를 섞는다
+  pokemonData.sort(() => Math.random() - 0.5);
+
+  // 카드를 그린다
+  const cardGrid = document.querySelector(".cardGrid");
+  cardGrid.innerHTML = ''; // 기존 카드 초기화
+  pokemonData.forEach(pokemon => {
+    const card = document.createElement("div");
+    card.classList.add("card");
+    card.dataset.name = pokemon.name;
+    card.innerHTML = `
+      <div class="front"></div>
+      <div class="back">
+        <img src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${getPokemonId(pokemon.url)}.png" alt="${pokemon.name}">
+      </div>
+    `;
+    card.addEventListener("click", flipCard);
+    cardGrid.appendChild(card);
+  });
+
+  matches = 0; // 매치 초기화
+  document.querySelector(".gameComplete").style.display = 'none'; // 완료 메시지 숨기기
+}
+
+function getPokemonId(url) {
+  const parts = url.split('/');
+  return parts[parts.length - 2];
+}
+
+function flipCard() {
+  if (lockBoard) return;
+  if (this === firstCard) return;
+
+  this.classList.add("flipped");
+
+  if (!firstCard) {
+    firstCard = this;
+    return;
+  }
+
+  secondCard = this;
+  lockBoard = true;
+
+  checkForMatch();
+}
+
+function checkForMatch() {
+  const isMatch = firstCard.dataset.name === secondCard.dataset.name;
+
+  isMatch ? disableCards() : unflipCards();
+}
+
+function disableCards() {
+  firstCard.removeEventListener("click", flipCard);
+  secondCard.removeEventListener("click", flipCard);
+
+  firstCard.classList.add("matched");
+  secondCard.classList.add("matched");
+
+  resetBoard();
+  matches++;
+
+  if (matches === 10) {
+    setTimeout(showGameComplete, 500);
+  }
+}
+
+function unflipCards() {
+  setTimeout(() => {
+    firstCard.classList.remove("flipped");
+    secondCard.classList.remove("flipped");
+    resetBoard();
+  }, 1000);
+}
+
+function resetBoard() {
+  [firstCard, secondCard, lockBoard] = [null, null, false];
+}
+
+function showGameComplete() {
+  const gameCompleteElement = document.querySelector(".gameComplete");
+  gameCompleteElement.style.display = 'block';
+}
+
+// "다시 하기" 버튼 클릭 이벤트 리스너 추가
+document.querySelector(".restartButton").addEventListener("click", () => {
+  loadPokemons();
+});


### PR DESCRIPTION
## 구현한 기능

미니게임으로 **포켓몬 카드 짝 맞추기**를 구현했습니다.
매 게임마다 다른 오프셋을 설정하여, 각기 다른 10쌍의 포켓몬 카드가 화면에 뿌려지고, 사용자가 짝을 맞추면 한 쌍이 사라지며 게임이 진행됩니다.
모든 카드가 사라지게 되면 다시 하기 버튼을 통해 리트라이가 가능합니다.

## 수정한 기능

메인페이지 **다크모드 토글 기능 js 코드 리팩토링**을 진행했습니다.
기존에는 document.querySelector, document.querySelectorAll을 통해 개별적으로 클래스를 토글하여 불필요한 코드가 많았습니다.
또한, 이미지에 대해 if문을 각각 적용하여 직접적으로 경로를 변경했습니다.

리팩토링한 코드에서는

1. 클래스 토글 함수 toggleClass() 추가
2. 이미지 토글 함수 toggleImage() 추가
3. 이벤트 리스너 통합

위 3가지로 모든 다크모드 변경 사항을 하나의 click 이벤트 리스너에서 처리했고, 토글버튼 클릭시 toggleClass와 toggleImage 함수를 호출하여 모든 변경을 한 번에 처리했습니다.

-----

💌
기능 확인을 위해 1차적으로 커밋합니다! 게임은 구현이 되고 실행도 정상적으로 되는 것 테스트하였으므로, ui적으로 다듬어야 할 부분은 천천히 진행하겠습니다 :D