### PR TITLE
반응형 css 작업 완료

### DIFF
--- a/css/game_main_mo.css
+++ b/css/game_main_mo.css
@@ -1,0 +1,12 @@
+@charset "UTF-8";
+/* 포켓몬 게임 반응형 css */
+
+.gameCon {
+    width: 250px;
+}
+.gameCon > h3 {
+    font-size: 24px;
+}
+.gameCon > h3 > span {
+    font-size: 26px;
+}

--- a/css/game_main_xs.css
+++ b/css/game_main_xs.css
@@ -5,7 +5,8 @@
     width: 100vw;
     padding: 10px 20px;
 } */
-.gameSet img {
+.gameSet img,
+.gameSetDark img {
     width: 40px;
     height: 40px;
 }

--- a/css/game_main_xs.css
+++ b/css/game_main_xs.css
@@ -1,0 +1,32 @@
+@charset "UTF-8";
+/* 포켓몬 게임 xs 모바일 css */
+
+/* header {
+    width: 100vw;
+    padding: 10px 20px;
+} */
+.gameSet img {
+    width: 40px;
+    height: 40px;
+}
+.mainSec {
+    padding-bottom: 50px;
+}
+.mainSec > div:first-child {
+    gap: 0;
+}
+.mainSec > .gameBoxSet {
+    flex-direction: column;
+}
+.gameCon {
+    height: 250px;
+}
+.gameCon img {
+    height: 80px;
+}
+.gameCon > h3 {
+    font-size: 22px;
+}
+.gameCon > div { 
+    font-size: 24px;
+}

--- a/css/main.css
+++ b/css/main.css
@@ -211,6 +211,7 @@ h2 {
 body.darkMode #lightDarkToggle {
     background: url(/pokemon/img/dark_mode.png) no-repeat;
     border: none;
+    background-size: cover;
 }
 
 

--- a/css/main_mo.css
+++ b/css/main_mo.css
@@ -1,0 +1,24 @@
+@charset "UTF-8";
+/* 포켓몬 메인 반응형 css */
+
+h2 {
+    font-size: 36px;
+}
+.type {
+    width: 80vw;
+    /* overflow-x: scroll; */
+}
+.typeGroup {
+    flex-wrap: nowrap;
+    overflow-x: scroll;
+    justify-content: flex-start;
+    padding: 30px 20px;
+    gap: 15px;
+}
+.typeGroup p {
+    display: flex;
+    white-space: nowrap;
+}
+.menu {
+    left: -350px;
+}

--- a/css/main_xs.css
+++ b/css/main_xs.css
@@ -1,0 +1,45 @@
+@charset "UTF-8";
+/* 포켓몬 메인 xs 모바일 css */
+
+header {
+    width: 100vw;
+    padding: 10px 20px;
+}
+h2 {
+    font-size: 24px;
+}
+#search {
+    width: 70vw;    
+}
+input::placeholder {
+    font-size: 14px;
+}
+.typeGroup p {
+    font-size: 14px;
+    padding: 5px 15px;
+}
+.menu {
+    width: 250px;
+    padding-left: 30px;
+    top: 50px;
+}
+#monsterBall {
+    display: none;
+}
+.catMenu a {
+    font-size: 24px;
+}
+.userMenu p {
+    font-size: 18px;
+}
+.sort {
+    margin-top: 10px;
+}
+#menuBt {
+    width: 30px;
+}
+#lightDarkToggle {
+    width: 55px;
+    height: 30px;
+    background-size: cover;
+}

--- a/css/poke_card.css
+++ b/css/poke_card.css
@@ -17,25 +17,32 @@ body {
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    padding: 100px 0;
+    /* padding: 100px 0; */
     margin: 0;
     background-color: #ffffff;
+    /* height: 100vh; */
 }
 h1 {
     margin-bottom: 30px;
+    font-size: 28px;
 }
 .gameContainer {
     text-align: center;
+    height: 100%;
+    padding: 100px 0;
 }
 .cardGrid {
     display: grid;
     grid-template-columns: repeat(5, 1fr);
     gap: 10px;
     margin-top: 20px;
+    aspect-ratio: 5 / 4;
 }
 .card {
     width: 155px;
     height: 205px;
+    width: calc((70vw - 10px) / 5);
+    height: calc((205 / 155) * ((70vw - 10px) / 5));
     position: relative;
     transform-style: preserve-3d;
     transition: transform 0.6s;
@@ -83,6 +90,7 @@ h1 {
     position: fixed;
     top: 50%;
     left: 50%;
+    width: 75vw;
     transform: translate(-50%, -50%);
     font-size: 20px;
     background: rgba(255, 255, 255, 0.7);

--- a/css/poke_card_mo.css
+++ b/css/poke_card_mo.css
@@ -1,0 +1,9 @@
+@charset "UTF-8";
+/* 포켓몬 카드게임 반응형 css */
+
+.gameContainer {
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}

--- a/html/poke_card.html
+++ b/html/poke_card.html
@@ -4,9 +4,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>포켓몬 카드 짝 맞추기 게임</title>
+    <title>내 짝을 찾아줘!</title>
     <link rel="stylesheet" href="/pokemon/css/main.css">
+    <link rel="stylesheet" media="all and (max-width:1140px)" href="/pokemon/css/main_mo.css">
+    <link rel="stylesheet" media="all and (max-width:511px)" href="/pokemon/css/main_xs.css">
     <link rel="stylesheet" href="/pokemon/css/poke_card.css">
+    <link rel="stylesheet" media="all and (max-width:602px)" href="/pokemon/css/poke_card_mo.css">
     <link rel="stylesheet" href="/pokemon/css/poke_footer.css">
 </head>
 
@@ -27,7 +30,7 @@
         <div id="lightDarkToggle">light, dark mode toggle</div>
     </header>
     <div class="gameContainer">
-        <h1>포켓몬 카드 짝 맞추기 게임</h1>
+        <h1>내 짝을 찾아줘!</h1>
         <div class="cardGrid"></div>
         <div class="gameComplete">
             <p>축하합니다! 모든 카드를 맞췄습니다!</p>

--- a/html/poke_name_quiz.html
+++ b/html/poke_name_quiz.html
@@ -6,6 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>포켓몬 이름 퀴즈</title>
   <link rel="stylesheet" href="/pokemon/css/main.css">
+  <link rel="stylesheet" media="all and (max-width:770px)" href="/pokemon/css/main_mo.css">
+  <link rel="stylesheet" media="all and (max-width:511px)" href="/pokemon/css/main_xs.css">
   <link rel="stylesheet" href="/pokemon/css/poke_name_quiz.css">
   <link rel="stylesheet" href="/pokemon/css/poke_footer.css">
 

--- a/html/pokemon_game_main.html
+++ b/html/pokemon_game_main.html
@@ -9,7 +9,10 @@
   <link rel="stylesheet" href="/pokemon/css/main.css">
   <link rel="stylesheet" href="/pokemon/css/game_main.css">
   <link rel="stylesheet" href="/pokemon/css/poke_footer.css">
-
+  <link rel="stylesheet" media="all and (max-width:770px)" href="/pokemon/css/main_mo.css">
+  <link rel="stylesheet" media="all and (max-width:770px)" href="/pokemon/css/game_main_mo.css">
+  <link rel="stylesheet" media="all and (max-width:577px)" href="/pokemon/css/main_xs.css">
+  <link rel="stylesheet" media="all and (max-width:577px)" href="/pokemon/css/game_main_xs.css">
 </head>
 
 <body>

--- a/html/pokemon_main.html
+++ b/html/pokemon_main.html
@@ -7,6 +7,8 @@
     <title>우리만의 포켓몬 도감</title>
     <script src="https://kit.fontawesome.com/650017f151.js" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="/pokemon/css/main.css">
+    <link rel="stylesheet" media="all and (max-width:770px)" href="/pokemon/css/main_mo.css">
+    <link rel="stylesheet" media="all and (max-width:511px)" href="/pokemon/css/main_xs.css">
 </head>
 
 <body>


### PR DESCRIPTION
## 💄 구현 작업
 
메인, 게임, 카드게임 페이지 반응형 css 작업


## 💦 발생했던 이슈 & 해결

카드 게임의 경우 5*4 배열의 카드가 grid로 되어 있고, 화면 크기가 줄어듦에 따라 미세하게 카드 크기를 조정해야 했기에 불필요하게 css 파일을 많이 만드는 쪽으로 접근했었습니다.
다른 css는 건드릴 것이 없고, 카드의 크기만 화면 크기에 따라 유동적이게 변하면 되었기에 카드의 width, height를 calc로 설정하여 해결하였습니다.

```
width: calc((70vw - 10px) / 5);
/* 70vw를 기준으로 카드 그리드 간격이 10px을 뺀 다음, 5개 열로 나눔 */

height: calc((205 / 155) * ((70vw - 10px) / 5));
/* 카드의 원래 비율이었던 205px, 155px을 유지하면서 위에서 계산한 카드 너비를 기준으로 높이 설정 */
```




